### PR TITLE
Make odrive versionless

### DIFF
--- a/Casks/odrive.rb
+++ b/Casks/odrive.rb
@@ -1,10 +1,7 @@
 cask 'odrive' do
-  version '5091'
-  sha256 'a44fea98d387ae0e917703446baa35eea5da5022d49e6cd9fd4307ba8f709cbb'
+  version :latest
 
-  # downloads can be found at https://www.odrive.com/downloaddesktop
-  # d3huse1s6vwzq6.cloudfront.net was verified as official when first introduced to the cask
-  url "https://d3huse1s6vwzq6.cloudfront.net/odrivesync.#{version}.dmg"
+  url "https://www.odrive.com/downloaddesktop?platform=mac"
   name 'odrive'
   homepage 'https://app.odrive.com/'
   license :gratis


### PR DESCRIPTION
Odrive seems to follow a rapid release cycle and old versions are remove from the CDN (the cask is currently broken).

I suggest changing it to a :latest cask. One question though: How do I solve the problem, that the version then is unknown, but the .pkg has it in it's name?
